### PR TITLE
Setting a source directory other than "src"

### DIFF
--- a/src/OpenWrap.Commands/Wrap/InitWrapCommand.cs
+++ b/src/OpenWrap.Commands/Wrap/InitWrapCommand.cs
@@ -22,6 +22,7 @@ namespace OpenWrap.Commands.Wrap
         public InitWrapCommand()
         {
             Target = ".";
+            SrcDir = "src";
         }
 
         [CommandInput]
@@ -48,6 +49,9 @@ namespace OpenWrap.Commands.Wrap
 
         [CommandInput]
         public string IgnoreFileName { get; set; }
+
+        [CommandInput]
+        public string SrcDir { get; set; }
 
         [CommandInput(Position = 0)]
         public string Target { get; set; }
@@ -89,6 +93,11 @@ namespace OpenWrap.Commands.Wrap
                 IgnoreFileName = ".bzrignore";
         }
 
+        void AddSourceDirecotry(PackageDescriptor packageDescriptor)
+        {
+            packageDescriptor.SourceDirectory = SrcDir;
+        }
+
         void AddOpenWrapDependency(PackageDescriptor packageDescriptor)
         {
             packageDescriptor.Dependencies.Add(new PackageDependency { Name = "openwrap", ContentOnly = true });
@@ -96,7 +105,7 @@ namespace OpenWrap.Commands.Wrap
 
         void AddPackageFolders(IDirectory projectDirectory)
         {
-            projectDirectory.GetDirectory("src").MustExist();
+            projectDirectory.GetDirectory(SrcDir).MustExist();
             projectDirectory.GetDirectory("wraps").GetDirectory("_cache").MustExist();
         }
 
@@ -195,6 +204,7 @@ namespace OpenWrap.Commands.Wrap
             }
             else
             {
+                AddSourceDirecotry(packageDescriptor);
                 AddOpenWrapDependency(packageDescriptor);
                 AddPackageFolders(projectDirectory);
                 AddIgnores(projectDirectory);

--- a/src/OpenWrap.Tests/Commands/Wrap/initWrapCommand.cs
+++ b/src/OpenWrap.Tests/Commands/Wrap/initWrapCommand.cs
@@ -41,6 +41,14 @@ namespace init_wrap_specs
                 .ShouldNotBeNull()
                 .ContentOnly.ShouldBeTrue();
         }
+        
+        [Test]
+        public void descriptor_return_the_default_source_directory()
+        {
+            new PackageDescriptorReaderWriter()
+                .Read(Environment.CurrentDirectory.GetFile("newpackage.wrapdesc"))
+                .SourceDirectory.ShouldNotBeNullOrEmpty("Descriptor was null").EqualsNoCase("src");
+        }
         [Test]
         public void openwrap_package_is_installed()
         {
@@ -54,7 +62,39 @@ namespace init_wrap_specs
             Environment.CurrentDirectory.GetDirectory("wraps").GetDirectory("openwrap")
                     .Exists.ShouldBeTrue();
         }
+
+        [Test]
+        public void default_src_directory_is_present()
+        {
+            Environment.CurrentDirectory.GetDirectory("src").Exists.ShouldBeTrue();
+        }
     }
+
+    class init_wrap_in_empty_dot_folder_custom_src : context.init_wrap
+    {
+        public init_wrap_in_empty_dot_folder_custom_src()
+        {
+            given_current_directory(@"c:\newpackage");
+            given_project_repository(new FolderRepository(Environment.CurrentDirectory.GetDirectory("wraps")));
+            when_executing_command(".", "-srcdir", "code");
+            Environment.ProjectRepository.Refresh();
+        }
+
+        [Test]
+        public void custom_src_directory_is_present()
+        {
+            Environment.CurrentDirectory.GetDirectory("code").Exists.ShouldBeTrue();
+        }
+
+        [Test]
+        public void descriptor_should_contain_custom_src_directory()
+        {
+            new PackageDescriptorReaderWriter()
+                .Read(Environment.CurrentDirectory.GetFile("newpackage.wrapdesc"))
+                .SourceDirectory.ShouldNotBeNullOrEmpty("Descriptor was null").EqualsNoCase("code");
+        }
+    }
+
     class init_dot_in_existing_package : context.init_wrap
     {
         public init_dot_in_existing_package()

--- a/src/OpenWrap/Build/BuildEngines/ConventionMSBuildEngine.cs
+++ b/src/OpenWrap/Build/BuildEngines/ConventionMSBuildEngine.cs
@@ -28,12 +28,12 @@ namespace OpenWrap.Build.BuildEngines
         public IEnumerable<BuildResult> Build()
         {
             var currentDirectory = _environment.CurrentDirectory;
-            var sourceDirectory = currentDirectory.GetDirectory("src");
+            var sourceDirectory = currentDirectory.GetDirectory(_environment.Descriptor.SourceDirectory);
             if (!sourceDirectory.Exists)
             {
                 yield return
-                        new ErrorBuildResult(string.Format("Could not locate a /src folder in current directory '{0}'. Make sure you use the default layout for project code.",
-                                                          _environment.CurrentDirectory.Path.FullPath));
+                        new ErrorBuildResult(string.Format("Could not locate a /{0} folder in current directory '{1}'. Make sure you use the default layout for project code, or add \"source-directory /MyCode\" to your wrapdesc.",
+                                                          _environment.Descriptor.SourceDirectory, _environment.CurrentDirectory.Path.FullPath));
                 yield break;
             }
             

--- a/src/OpenWrap/Dependencies/PackageDescriptor.cs
+++ b/src/OpenWrap/Dependencies/PackageDescriptor.cs
@@ -28,6 +28,7 @@ namespace OpenWrap.Dependencies
             Description = "";
             UseProjectRepository = true;
             CreationTime = DateTimeOffset.UtcNow;
+            SourceDirectory = "src";
         }
 
         public ICollection<PackageDependency> Dependencies { get; set; }
@@ -62,6 +63,8 @@ namespace OpenWrap.Dependencies
         public bool Anchored { get; set; }
 
         public string BuildCommand { get; set; }
+
+        public string SourceDirectory { get; set; }
 
         public bool IsCompatibleWith(Version version)
         {

--- a/src/OpenWrap/Dependencies/PackageDescriptorReaderWriter.cs
+++ b/src/OpenWrap/Dependencies/PackageDescriptorReaderWriter.cs
@@ -20,6 +20,7 @@ namespace OpenWrap.Dependencies
 
         readonly IEnumerable<IDescriptorParser> _lineParsers = new List<IDescriptorParser>
         {
+            new SourceDirectoryParser(),
             new DependsParser(),
             new DescriptionParser(),
             new OverrideParser(),

--- a/src/OpenWrap/Dependencies/Parsers/SourceDirectoryParser.cs
+++ b/src/OpenWrap/Dependencies/Parsers/SourceDirectoryParser.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace OpenWrap.Dependencies.Parsers
+{
+    public class SourceDirectoryParser : AbstractDescriptorParser
+    {
+        public SourceDirectoryParser() : base("source-directory") { }
+
+        protected override void ParseContent(string content, PackageDescriptor descriptor)
+        {
+            string source = content.Trim();
+            descriptor.SourceDirectory = string.IsNullOrEmpty(source) ? null : source;
+        }
+        protected override IEnumerable<string> WriteContent(PackageDescriptor descriptor)
+        {
+            if (!string.IsNullOrEmpty(descriptor.SourceDirectory))
+                yield return descriptor.SourceDirectory;
+        }
+    }
+}

--- a/src/OpenWrap/OpenWrap.csproj
+++ b/src/OpenWrap/OpenWrap.csproj
@@ -131,6 +131,7 @@
     <Compile Include="ConsoleRunner.cs" />
     <Compile Include="Dependencies\DefaultPackageInfo.cs" />
     <Compile Include="Dependencies\GreaterThanVersionVertex.cs" />
+    <Compile Include="Dependencies\Parsers\SourceDirectoryParser.cs" />
     <Compile Include="Dependencies\StringExtensions.cs" />
     <Compile Include="IOExtensions.cs" />
     <Compile Include="Dependencies\PackageBuilder.cs" />


### PR DESCRIPTION
Allows someone to change a source directory by calling `o init . -srcdir "mycode"`. If this is not present, then it defaults to the standard "src"
