### PR TITLE
Issue88: remote set: rename remote to new name

### DIFF
--- a/src/OpenWrap.Commands/CommandDocumentation.resx
+++ b/src/OpenWrap.Commands/CommandDocumentation.resx
@@ -304,6 +304,9 @@ Note that the NuPack support is only provided for backward compatibility with le
   <data name="set-remote" xml:space="preserve">
     <value>Updates a remote repository's metadata.</value>
   </data>
+  <data name="set-remote-href" xml:space="preserve">
+    <value>Specify a new href for an existing repository.</value>
+  </data>
   <data name="set-remote-name" xml:space="preserve">
     <value>Specifies the name of the remote repository to update.</value>
   </data>

--- a/src/OpenWrap.Commands/CommandDocumentation.resx
+++ b/src/OpenWrap.Commands/CommandDocumentation.resx
@@ -307,6 +307,9 @@ Note that the NuPack support is only provided for backward compatibility with le
   <data name="set-remote-name" xml:space="preserve">
     <value>Specifies the name of the remote repository to update.</value>
   </data>
+  <data name="set-remote-newname" xml:space="preserve">
+    <value>Specify a new name for the repository you are changing</value>
+  </data>
   <data name="set-remote-position" xml:space="preserve">
     <value>Updates the integer position used to order remote repositories.</value>
   </data>

--- a/src/OpenWrap.Commands/Remote/SetRemoteCommand.cs
+++ b/src/OpenWrap.Commands/Remote/SetRemoteCommand.cs
@@ -18,6 +18,9 @@ namespace OpenWrap.Commands.Remote
             set { _position = value; }
         }
 
+        [CommandInput]
+        public string NewName { get; set; }
+
         IConfigurationManager ConfigurationManager { get { return Services.Services.GetService<IConfigurationManager>(); } }
 
         public override IEnumerable<ICommandOutput> Execute()
@@ -33,6 +36,16 @@ namespace OpenWrap.Commands.Remote
             if (_position.HasValue)
             {
                 remote.Priority = _position.Value;
+            }
+
+            if (!string.IsNullOrEmpty(NewName))
+            {
+                if (repositories.ContainsKey(NewName))
+                {
+                    yield return new Error("Repository with name '{0}' already present.");
+                    yield break;
+                }
+                remote.Name = NewName;
             }
 
             ConfigurationManager.SaveRemoteRepositories(repositories);

--- a/src/OpenWrap.Commands/Remote/SetRemoteCommand.cs
+++ b/src/OpenWrap.Commands/Remote/SetRemoteCommand.cs
@@ -24,6 +24,9 @@ namespace OpenWrap.Commands.Remote
         [CommandInput]
         public string NewName { get; set; }
 
+        [CommandInput]
+        public Uri Href { get; set; }
+
         IConfigurationManager ConfigurationManager { get { return Services.Services.GetService<IConfigurationManager>(); } }
 
         public override IEnumerable<ICommandOutput> Execute()
@@ -47,6 +50,11 @@ namespace OpenWrap.Commands.Remote
                     yield break;
                 }
                 remote.Name = NewName;
+            }
+
+            if (Href != null)
+            {
+                remote.Href = Href;
             }
 
             ConfigurationManager.SaveRemoteRepositories(repositories);

--- a/src/OpenWrap.Tests/Commands/Remote/setRemoteCommand.cs
+++ b/src/OpenWrap.Tests/Commands/Remote/setRemoteCommand.cs
@@ -18,8 +18,9 @@ namespace OpenWrap.Tests.Commands.Remote.Set
                 given_remote_configuration(
                            new RemoteRepositories
                     {
-                            { "paralox", new RemoteRepository { Name = "paralox", Priority = 1 } },
-                            { "es", new RemoteRepository { Name = "es", Priority = 2 } }
+                            { "primus", new RemoteRepository { Name = "primus", Priority = 1 } },
+                            { "secundus", new RemoteRepository { Name = "secundus", Priority = 2 } },
+                            { "terz", new RemoteRepository { Name = "terz", Priority = 3 } }
                     });
             }
 
@@ -37,13 +38,13 @@ namespace OpenWrap.Tests.Commands.Remote.Set
     {
         public when_changing_remote_priority()
         {
-            when_executing_command("es", "-priority", "1");
+            when_executing_command("secundus", "-priority", "1");
         }
 
         [Test]
         public void the_second_repository_has_new_priority()
         {
-            var remote = TryGetRepository("es");
+            var remote = TryGetRepository("secundus");
             remote.Priority.ShouldBe(1);
         }
     }
@@ -52,13 +53,13 @@ namespace OpenWrap.Tests.Commands.Remote.Set
     {
         public when_changing_repository_name()
         {
-            when_executing_command("es", "-newname", "vamu");
+            when_executing_command("secundus", "-newname", "vamu");
         }
 
         [Test]
         public void the_second_repository_has_new_name()
         {
-            var remote = TryGetRepository("es");
+            var remote = TryGetRepository("secundus");
             remote.Name.ShouldBe("vamu");
         }
     }
@@ -67,7 +68,7 @@ namespace OpenWrap.Tests.Commands.Remote.Set
     {
         public when_changing_repository_name_to_existing()
         {
-            when_executing_command("es", "-newname", "paralox");
+            when_executing_command("secundus", "-newname", "primus");
         }
 
         [Test]
@@ -76,5 +77,68 @@ namespace OpenWrap.Tests.Commands.Remote.Set
             Results.ShouldContain<Error>();
         }
     }
-    
+
+    public class moving_repository_to_new_priority_case1 : set_remote
+    {
+        public moving_repository_to_new_priority_case1()
+        {
+            when_executing_command("terz", "-priority", "1");
+        }
+
+        [Test]
+        public void rearranges_priorities()
+        {
+            TryGetRepository("terz").Priority.ShouldBe(1);
+            TryGetRepository("primus").Priority.ShouldBe(2);
+            TryGetRepository("secundus").Priority.ShouldBe(3);
+        }
+    }
+
+    public class moving_repository_to_new_priority_case2 : set_remote
+    {
+        public moving_repository_to_new_priority_case2()
+        {
+            when_executing_command("secundus", "-priority", "1");
+        }
+
+        [Test]
+        public void rearranges_priorities()
+        {
+            TryGetRepository("secundus").Priority.ShouldBe(1);
+            TryGetRepository("primus").Priority.ShouldBe(2);
+            TryGetRepository("terz").Priority.ShouldBe(3);
+        }
+    }
+
+    public class moving_repository_to_new_priority_case3 : set_remote
+    {
+        public moving_repository_to_new_priority_case3()
+        {
+            when_executing_command("primus", "-priority", "2");
+        }
+
+        [Test]
+        public void rearranges_priorities()
+        {
+            TryGetRepository("secundus").Priority.ShouldBe(1);
+            TryGetRepository("primus").Priority.ShouldBe(2);
+            TryGetRepository("terz").Priority.ShouldBe(3);
+        }
+    }
+
+    public class moving_repository_to_new_priority_case4 : set_remote
+    {
+        public moving_repository_to_new_priority_case4()
+        {
+            when_executing_command("secundus", "-priority", "3");
+        }
+
+        [Test]
+        public void rearranges_priorities()
+        {
+            TryGetRepository("primus").Priority.ShouldBe(1);
+            TryGetRepository("terz").Priority.ShouldBe(2);
+            TryGetRepository("secundus").Priority.ShouldBe(3);
+        }
+    }
 }

--- a/src/OpenWrap.Tests/Commands/Remote/setRemoteCommand.cs
+++ b/src/OpenWrap.Tests/Commands/Remote/setRemoteCommand.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using NUnit.Framework;
+using OpenWrap.Commands;
+using OpenWrap.Commands.Remote;
+using OpenWrap.Configuration;
+using OpenWrap.Testing;
+using OpenWrap.Tests.Commands.context;
+using OpenWrap.Tests.Commands.Remote.Set.context;
+
+namespace OpenWrap.Tests.Commands.Remote.Set
+{
+    namespace context
+    {
+        public class set_remote : command_context<SetRemoteCommand>
+        {
+            public set_remote()
+            {
+                given_remote_configuration(
+                           new RemoteRepositories
+                    {
+                            { "paralox", new RemoteRepository { Name = "paralox", Priority = 1 } },
+                            { "es", new RemoteRepository { Name = "es", Priority = 2 } }
+                    });
+            }
+
+            public RemoteRepository TryGetRepository(string name)
+            {
+                var repositories = Services.Services.GetService<IConfigurationManager>().LoadRemoteRepositories();
+                RemoteRepository rep;
+                repositories.TryGetValue(name, out rep);
+                return rep;
+            }
+        }
+    }
+
+    public class when_changing_remote_priority : set_remote
+    {
+        public when_changing_remote_priority()
+        {
+            when_executing_command("es", "-priority", "1");
+        }
+
+        [Test]
+        public void the_second_repository_has_new_priority()
+        {
+            var remote = TryGetRepository("es");
+            remote.Priority.ShouldBe(1);
+        }
+    }
+
+    public class when_changing_repository_name : set_remote
+    {
+        public when_changing_repository_name()
+        {
+            when_executing_command("es", "-newname", "vamu");
+        }
+
+        [Test]
+        public void the_second_repository_has_new_name()
+        {
+            var remote = TryGetRepository("es");
+            remote.Name.ShouldBe("vamu");
+        }
+    }
+
+    public class when_changing_repository_name_to_existing : set_remote
+    {
+        public when_changing_repository_name_to_existing()
+        {
+            when_executing_command("es", "-newname", "paralox");
+        }
+
+        [Test]
+        public void should_return_error()
+        {
+            Results.ShouldContain<Error>();
+        }
+    }
+    
+}

--- a/src/OpenWrap.Tests/Commands/Remote/setRemoteCommand.cs
+++ b/src/OpenWrap.Tests/Commands/Remote/setRemoteCommand.cs
@@ -64,6 +64,21 @@ namespace OpenWrap.Tests.Commands.Remote.Set
         }
     }
 
+    public class when_changing_repository_href : set_remote
+    {
+        public when_changing_repository_href()
+        {
+            when_executing_command("secundus", "-href", "http://awesomereps.net");
+        }
+
+        [Test]
+        public void the_second_repository_has_new_href()
+        {
+            var remote = TryGetRepository("secundus");
+            remote.Href.ShouldBe("http://awesomereps.net");
+        }
+    }
+
     public class when_changing_repository_name_to_existing : set_remote
     {
         public when_changing_repository_name_to_existing()

--- a/src/OpenWrap.Tests/OpenWrap.Tests.csproj
+++ b/src/OpenWrap.Tests/OpenWrap.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Commands\Core\gac_resolve_spec.cs" />
     <Compile Include="Commands\Help\getHelpCommand.cs" />
     <Compile Include="Commands\Remote\addRemoteCommand.cs" />
+    <Compile Include="Commands\Remote\setRemoteCommand.cs" />
     <Compile Include="Commands\Remote\listRemoteCommand.cs" />
     <Compile Include="Commands\Remote\removeRemoteCommand.cs" />
     <Compile Include="Commands\Wrap\addWrapCommand.cs" />

--- a/src/OpenWrap/Collections/EnumerableExtensions.cs
+++ b/src/OpenWrap/Collections/EnumerableExtensions.cs
@@ -41,6 +41,11 @@ namespace OpenWrap.Collections
             return input.Where(x => !string.IsNullOrEmpty(x));
         }
 
+        public static IEnumerable<T> ToEnumerable<T>(this T item)
+        {
+            return new[] { item };
+        }
+
         public static MoveNextResult TryMoveNext<T, TException>(this IEnumerator<T> enumerator, out T value, out TException error)
                 where TException : Exception
         {


### PR DESCRIPTION
- `o set-remote -name x -newname y` is now supported
- `o set-remote -name x -href http://newuri` is now supported
- a fix to rearrange repository priorities when a user specifies a new priority for some repository. Priorities will be shuffled up/downwards depending whether the new priority is lower or higher.
- supporting tests
