### PR TITLE
Issue 126: Comments in descriptor

### DIFF
--- a/src/OpenWrap/OpenWrap.csproj
+++ b/src/OpenWrap/OpenWrap.csproj
@@ -110,6 +110,7 @@
     <Compile Include="PackageManagement\PackageListResultIterator.cs" />
     <Compile Include="PackageManagement\PackageRemoveResultIterator.cs" />
     <Compile Include="PackageManagement\PackageUpdateResultIterator.cs" />
+    <Compile Include="PackageModel\CommentDescriptorEntry.cs" />
     <Compile Include="PackageModel\LessThanOrEqualVersionVertex.cs" />
     <Compile Include="Repositories\NuGet\NuSpecConverter.cs" />
     <Compile Include="PackageManagement\Monitoring\IResolvedAssembliesUpdateListener.cs" />

--- a/src/OpenWrap/PackageModel/CommentDescriptorEntry.cs
+++ b/src/OpenWrap/PackageModel/CommentDescriptorEntry.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+
+namespace OpenWrap.PackageModel
+{
+    public class CommentDescriptorEntry : IPackageDescriptorEntry
+    {
+        public CommentDescriptorEntry(string value)
+        {
+            Value = value;
+        }
+
+        public string Name
+        {
+            get { return "COMMENT"; }
+        }
+
+        public string Value { get; private set; }
+
+        public void Write(TextWriter writer)
+        {
+            writer.Write("{0}\r\n", Value);
+        }
+    }
+}

--- a/src/OpenWrap/PackageModel/GenericDescriptorEntry.cs
+++ b/src/OpenWrap/PackageModel/GenericDescriptorEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace OpenWrap.PackageModel
 {
@@ -15,6 +16,11 @@ namespace OpenWrap.PackageModel
 
         public string Name { get; set; }
         public string Value { get; set; }
+
+        public void Write(TextWriter writer)
+        {
+            writer.Write(Name + ": " + Value + "\r\n");
+        }
 
         public static bool operator ==(GenericDescriptorEntry left, GenericDescriptorEntry right)
         {

--- a/src/OpenWrap/PackageModel/IPackageDescriptorEntry.cs
+++ b/src/OpenWrap/PackageModel/IPackageDescriptorEntry.cs
@@ -1,8 +1,11 @@
-﻿namespace OpenWrap.PackageModel
+﻿using System.IO;
+
+namespace OpenWrap.PackageModel
 {
     public interface IPackageDescriptorEntry
     {
         string Name { get; }
         string Value { get; }
+        void Write(TextWriter writer);
     }
 }

--- a/src/OpenWrap/PackageModel/PackageDescriptor.cs
+++ b/src/OpenWrap/PackageModel/PackageDescriptor.cs
@@ -24,7 +24,7 @@ namespace OpenWrap.PackageModel
         public PackageDescriptor(IEnumerable<IPackageDescriptorEntry> entries)
         {
             foreach (var line in entries)
-                _entries.Append(line.Name, line.Value);
+                _entries.Append(line);
             InitializeHeaders();
         }
 

--- a/src/OpenWrap/PackageModel/PackageDescriptorEntryCollection.cs
+++ b/src/OpenWrap/PackageModel/PackageDescriptorEntryCollection.cs
@@ -8,26 +8,22 @@ namespace OpenWrap.PackageModel
 {
     public class PackageDescriptorEntryCollection : IEnumerable<IPackageDescriptorEntry>
     {
-        readonly Dictionary<string, List<GenericDescriptorEntry>> _byName = new Dictionary<string, List<GenericDescriptorEntry>>(StringComparer.OrdinalIgnoreCase);
-        readonly List<GenericDescriptorEntry> _headers = new List<GenericDescriptorEntry>();
+        readonly Dictionary<string, List<IPackageDescriptorEntry>> _byName = new Dictionary<string, List<IPackageDescriptorEntry>>(StringComparer.OrdinalIgnoreCase);
+        readonly List<IPackageDescriptorEntry> _headers = new List<IPackageDescriptorEntry>();
 
-        public PackageDescriptorEntryCollection(IEnumerable<KeyValuePair<string, string>> descriptorLines)
+        
+        public IPackageDescriptorEntry Append(IPackageDescriptorEntry entry)
         {
-            foreach (var value in descriptorLines)
-                Append(value.Key, value.Value);
-        }
-
-        public PackageDescriptorEntryCollection()
-        {
+            if (!_headers.Contains(entry))
+                _headers.Add(entry);
+            GetOrAddValueList(entry.Name).Add(entry);
+            return entry;
         }
 
         public IPackageDescriptorEntry Append(string name, string value)
         {
             var header = new GenericDescriptorEntry(name, value);
-            if (!_headers.Contains(header))
-                _headers.Add(header);
-            GetOrAddValueList(name).Add(header);
-            return header;
+            return Append(header);
         }
 
         public void Remove(string name)
@@ -78,11 +74,11 @@ namespace OpenWrap.PackageModel
                 yield return val;
         }
 
-        List<GenericDescriptorEntry> GetOrAddValueList(string name)
+        List<IPackageDescriptorEntry> GetOrAddValueList(string name)
         {
-            List<GenericDescriptorEntry> values;
+            List<IPackageDescriptorEntry> values;
             if (!_byName.TryGetValue(name, out values))
-                _byName[name] = values = new List<GenericDescriptorEntry>();
+                _byName[name] = values = new List<IPackageDescriptorEntry>();
             return values;
         }
     }

--- a/src/OpenWrap/PackageModel/Serialization/PackageDescriptorReaderWriter.cs
+++ b/src/OpenWrap/PackageModel/Serialization/PackageDescriptorReaderWriter.cs
@@ -59,14 +59,15 @@ namespace OpenWrap.PackageModel.Serialization
         {
             var streamWriter = new StreamWriter(descriptorStream, Encoding.UTF8);
             foreach (var line in descriptor)
-            {
-                streamWriter.Write(line.Name + ": " + line.Value + "\r\n");
-            }
+                line.Write(streamWriter);
             streamWriter.Flush();
         }
 
         IPackageDescriptorEntry ParseLine(string line)
         {
+            if (line.TrimStart(' ').StartsWith("#"))
+                return new CommentDescriptorEntry(line);
+
             var match = _lineParser.Match(line);
             return !match.Success
                            ? null


### PR DESCRIPTION
Hi Seb, I've added ability to put comments into descriptor file. 

Unfortunately I had to do a few more changes that I wanted to because you had some leakage regarding _name_ and _value_ around, which doesn't make much sense for comments. It should actually be a bit more Open/Closed-based now.

There is a slight change in that there will be an additional return+newline written, but it doesn't match and hence is ignored as far as I can see.
