### PR TITLE
Minor fixes in OpenRasta.Client

### DIFF
--- a/src/OpenRasta.Client/HttpWebRequestBasedRequest.cs
+++ b/src/OpenRasta.Client/HttpWebRequestBasedRequest.cs
@@ -36,12 +36,14 @@ namespace OpenRasta.Client
 
         void SendRequestStream()
         {
-            var streamToWriteTo = _request.GetRequestStream();
             if (_entity.Stream.CanSeek)
-            {
                 _request.ContentLength = _entity.Stream.Length;
+
+            var streamToWriteTo = _request.GetRequestStream();
+
+            if (_entity.Stream.CanSeek)
                 streamToWriteTo = new ProgressStream(_entity.Stream.Length, RaiseProgress, streamToWriteTo);
-            }
+
             _entity.Stream.CopyTo(streamToWriteTo);
         }
 

--- a/src/OpenRasta.Client/RequestExtensions.cs
+++ b/src/OpenRasta.Client/RequestExtensions.cs
@@ -49,7 +49,7 @@ namespace OpenRasta.Client
         {
             var reader = response.AsXmlReader<T>();
             if (reader == null) return null;
-            return XDocument.Load(reader);
+            return XDocument.Load(reader, LoadOptions.SetBaseUri);
         }
     }
 }


### PR DESCRIPTION
Hi,

I came across 2 buggs in OpenRasta.Client code while preparing SymbolSource integration. You might have noticed these also during your work on OpenWrap repository server, as they prevent remote package publishing. If not, I fixed them on my fork and you can pull the changes. They are fairly simple and self-explanatory. First one caused publish URI building to fail, the second prevents sending packages with an error stating that ContentLenght should be set before opening the request stream.

Regards,
Marcin Mikołajczak
