### PR TITLE
Fixed bugs in InitializeOpenWrap and OpewnWrap.CSharp.targets

### DIFF
--- a/src/OpenWrap.Build.Bootstrap/InitializeOpenWrap.cs
+++ b/src/OpenWrap.Build.Bootstrap/InitializeOpenWrap.cs
@@ -22,7 +22,7 @@ namespace OpenWrap.Build
             if (StartDebug)
                 Debugger.Launch();
             var asm = Preloader.LoadAssemblies(
-                    Preloader.GetPackageFolders(Preloader.RemoteInstall.None, DefaultInstallationPaths.SystemRepositoryDirectory,"openwrap", "openfilesystem", "sharpziplib")
+                    Preloader.GetPackageFolders(Preloader.RemoteInstall.None, null, DefaultInstallationPaths.SystemRepositoryDirectory, "openwrap",  "openfilesystem", "sharpziplib")
                     );
             foreach (var assembly in asm.Select(x => x.Key))
                 this.Log.LogMessage(MessageImportance.Low, "Pre-loaded assembly " + assembly);

--- a/src/OpenWrap.Build.Tasks/OpenWrap.CSharp.targets
+++ b/src/OpenWrap.Build.Tasks/OpenWrap.CSharp.targets
@@ -44,7 +44,7 @@
   </ItemGroup>
   <Target Name="_Initialize">
     <InitializeOpenWrap StartDebug="$(OpenWrap-StartDebug)" >
-      <Output TaskParameter="Name" PropertyName="OpenWrap-PackageName" />L
+      <Output TaskParameter="Name" PropertyName="OpenWrap-PackageName" />
     </InitializeOpenWrap>
 
     <InitializeVisualStudioIntegration


### PR DESCRIPTION
Fixed bugs:
- InitializeOpenWrap.Execute - add parameter
- removed 'L' letter in OpenWrap.CSharp.targets
