### PR TITLE
Handle descriptor files with *nix line endings (\n instead of \r\n)

### DIFF
--- a/src/OpenWrap/PackageModel/Serialization/StringExtensions.cs
+++ b/src/OpenWrap/PackageModel/Serialization/StringExtensions.cs
@@ -6,12 +6,12 @@ namespace OpenWrap.PackageModel.Serialization
 {
     public static class StringExtensions
     {
-        static readonly Regex _foldableLines = new Regex(@"\r\n[\f\t\v\x85\p{Z}]+", RegexOptions.Multiline | RegexOptions.Compiled);
+        static readonly Regex _foldableLines = new Regex(@"\r?\n[\f\t\v\x85\p{Z}]+", RegexOptions.Multiline | RegexOptions.Compiled);
 
         public static string[] GetUnfoldedLines(this string content)
         {
             content = _foldableLines.Replace(content, " ");
-            var linesToProcess = content.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+            var linesToProcess = content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
             return linesToProcess
                     .Select(x => x.Trim())
                     .Where(x => x != string.Empty)


### PR DESCRIPTION
We happen to use bzr here at work, and thanks to a missing configuration step, our continuous integration server ended up checking out all the files from my branch making use of OpenWrap with all unix line endings instead of Windows native line endings. I've since fixed that issue with our build server checkouts, but I thought it might be helpful in general if this worked as expected.

This fix _should_ fix it, all the existing unit tests all still pass. I wasn't sure the best spot to put _new_ unit tests to verify this fix works as expected. If someone wants to give me input on that, I'll gladly add them.
