### PR TITLE
Descriptor files with only <LF> do not generate an error

### DIFF
--- a/src/OpenWrap/PackageModel/Serialization/PackageDescriptorReader.cs
+++ b/src/OpenWrap/PackageModel/Serialization/PackageDescriptorReader.cs
@@ -48,6 +48,9 @@ namespace OpenWrap.PackageModel.Serialization
         {
             var stringReader = new StreamReader(content, true);
             var lines = stringReader.ReadToEnd().GetUnfoldedLines();
+            if (lines.Any(l => l.Contains('\n')))
+                throw new InvalidPackageException("Package descriptor contains invalid line endings.");
+
             return ctor != null
                 ? ctor(lines.Select(ParseLine))
                 : new PackageDescriptor(lines.Select(ParseLine)) as T;

--- a/src/OpenWrap/PackageModel/Serialization/PackageDescriptorReaderWriter.cs
+++ b/src/OpenWrap/PackageModel/Serialization/PackageDescriptorReaderWriter.cs
@@ -36,6 +36,10 @@ namespace OpenWrap.PackageModel.Serialization
                         return descriptor;
                     }
                 }
+                catch (InvalidPackageException ex)
+                {
+                    throw new InvalidPackageException(String.Format("Invalid package for file '{0}'.", filePath.Path), ex);
+                }
                 catch (IOException ex)
                 {
                     ioException = ex;


### PR DESCRIPTION
This is a followup to my preview pull request.

I haven't been able to test this locally (any docs/blog posts on how to test things like this?) but I think this would handle this as expected.

Thoughts?
