### PR TITLE
init-wrap: new -Name input

### DIFF
--- a/src/OpenWrap.Commands/CommandDocumentation.resx
+++ b/src/OpenWrap.Commands/CommandDocumentation.resx
@@ -229,6 +229,9 @@ Note that the NuPack support is only provided for backward compatibility with le
   <data name="init-wrap-nosymlinks" xml:space="preserve">
     <value>Specifies that OpenWrap should use file copies instead of symlinks, typically used for source-control systems that have issues with symlinks such as subversion.</value>
   </data>
+  <data name="init-wrap-packagename" xml:space="preserve">
+    <value>Specifies the package name to initialize. If -Target is specified, the default is the directory name specified there, otherwise the default is the current directory name.</value>
+  </data>
   <data name="init-wrap-projects" xml:space="preserve">
     <value>Specifies a semi-column-separated paths to msbuild files to update to use OpenWrap for assembly resolution.</value>
   </data>

--- a/src/OpenWrap.Commands/CommandDocumentation.resx
+++ b/src/OpenWrap.Commands/CommandDocumentation.resx
@@ -223,14 +223,14 @@ Note that the NuPack support is only provided for backward compatibility with le
   <data name="init-wrap-meta" xml:space="preserve">
     <value>Specifies that the target is a meta-package, aka a combination of other packages without build provider or project repository.</value>
   </data>
+  <data name="init-wrap-name" xml:space="preserve">
+    <value>Specifies the package name to initialize. If -Target is specified, the default is the directory name specified there, otherwise the default is the current directory name.</value>
+  </data>
   <data name="init-wrap-nosymlink" xml:space="preserve">
     <value>Specifies if symlinks are to be used for anchoring. If synlinks are not in use, anchored packages will be copied in the correct folders instead.</value>
   </data>
   <data name="init-wrap-nosymlinks" xml:space="preserve">
     <value>Specifies that OpenWrap should use file copies instead of symlinks, typically used for source-control systems that have issues with symlinks such as subversion.</value>
-  </data>
-  <data name="init-wrap-packagename" xml:space="preserve">
-    <value>Specifies the package name to initialize. If -Target is specified, the default is the directory name specified there, otherwise the default is the current directory name.</value>
   </data>
   <data name="init-wrap-projects" xml:space="preserve">
     <value>Specifies a semi-column-separated paths to msbuild files to update to use OpenWrap for assembly resolution.</value>

--- a/src/OpenWrap.Commands/Wrap/InitWrapCommand.cs
+++ b/src/OpenWrap.Commands/Wrap/InitWrapCommand.cs
@@ -24,7 +24,7 @@ namespace OpenWrap.Commands.Wrap
         bool? _allProjects;
         IEnumerable<IFile> _projectsToPatch;
         IFile _packageDescriptorFile;
-        string _packageName;
+        string _name;
 
         public InitWrapCommand()
         {
@@ -66,10 +66,10 @@ namespace OpenWrap.Commands.Wrap
         public string Target { get; set; }
 
         [CommandInput (Position = 1)]
-        public string PackageName
+        public string Name
         {
-            get { return _packageName ?? (Target == "." ? Environment.CurrentDirectory.Name : Target); }
-            set { _packageName = value; }
+            get { return _name ?? (Target == "." ? Environment.CurrentDirectory.Name : Target); }
+            set { _name = value; }
         }
 
         IEnvironment Environment
@@ -204,7 +204,7 @@ namespace OpenWrap.Commands.Wrap
 
             IDirectory projectDirectory = Target == "." ? currentDirectory : currentDirectory.GetDirectory(Target);
 
-            string packageName = PackageName;
+            string packageName = Name;
 
             _packageDescriptorFile = projectDirectory.GetFile(packageName + ".wrapdesc");
             if (_packageDescriptorFile.Exists)

--- a/src/OpenWrap.Commands/Wrap/InitWrapCommand.cs
+++ b/src/OpenWrap.Commands/Wrap/InitWrapCommand.cs
@@ -24,6 +24,7 @@ namespace OpenWrap.Commands.Wrap
         bool? _allProjects;
         IEnumerable<IFile> _projectsToPatch;
         IFile _packageDescriptorFile;
+        string _packageName;
 
         public InitWrapCommand()
         {
@@ -63,6 +64,13 @@ namespace OpenWrap.Commands.Wrap
 
         [CommandInput(Position = 0)]
         public string Target { get; set; }
+
+        [CommandInput (Position = 1)]
+        public string PackageName
+        {
+            get { return _packageName ?? (Target == "." ? Environment.CurrentDirectory.Name : Target); }
+            set { _packageName = value; }
+        }
 
         IEnvironment Environment
         {
@@ -196,7 +204,7 @@ namespace OpenWrap.Commands.Wrap
 
             IDirectory projectDirectory = Target == "." ? currentDirectory : currentDirectory.GetDirectory(Target);
 
-            string packageName = Target == "." ? Environment.CurrentDirectory.Name : Target;
+            string packageName = PackageName;
 
             _packageDescriptorFile = projectDirectory.GetFile(packageName + ".wrapdesc");
             if (_packageDescriptorFile.Exists)


### PR DESCRIPTION
We use bzr for revision control, and very often use "feature branches" for doing our work. Since bzr uses separate directories for each branch, we often have a setup like:
- my-project-repo
  - mainline
    - MyProject.wrapdesc
  - ftr_branch_one
    - MyProject.wrapdesc
  - ftr_branch_two
    - MyProject.wrapdesc

When we add a new .csproj to the solution, we of course need to update the project file to use the OpenWrap targets instead of the default ones. As far as I know, the only way to do that is with the "init-wrap" command. Unfortunately, init-wrap uses the directory name for the package name, so doing something like:

"ftr_branch_two> o init-wrap -All true -NoSymlinks true -IgnoreFileName .bzrignore"

Results in a new ftr_branch_two.wrapdesc file getting generated. This then causes headaches for MSBuild, etc, etc.

This branch adds a new -PackageName parameter to init-wrap, so we can instead do:

"ftr_branch_two> o init-wrap -PackageName MyProject -All true -NoSymlinks true -IgnoreFileName .bzrignore"

And it detects the existing MyProject.wrapdesc and behaves as expected.

Thoughts? Suggestions on a better way to handle this?
