### PR TITLE
Fixed remote repository wrap listing

### DIFF
--- a/src/OpenRasta.Client/HttpWebRequestBasedRequest.cs
+++ b/src/OpenRasta.Client/HttpWebRequestBasedRequest.cs
@@ -63,7 +63,8 @@ namespace OpenRasta.Client
 
         public IClientResponse Send()
         {
-            _request.ContentType = _entity.ContentType.ToString();
+            //_request.ContentType = _entity.ContentType.ToString();
+                                                                
             RaiseStatusChanged("Connecting to {0}", RequestUri.ToString());
             if (_entity.Stream != null &&
                 ((_entity.Stream.CanSeek && _entity.Stream.Length > 0) ||

--- a/src/OpenWrap.Commands/Wrap/PublishWrapCommand.cs
+++ b/src/OpenWrap.Commands/Wrap/PublishWrapCommand.cs
@@ -49,7 +49,7 @@ namespace OpenWrap.Commands.Wrap
         protected override IEnumerable<Func<IEnumerable<ICommandOutput>>> Validators()
         {
             yield return ValidateInputs;
-            yield return ValidatePackageDoesntExist;
+            //yield return ValidatePackageDoesntExist;
         }
 
         IEnumerable<ICommandOutput> ValidateInputs()

--- a/src/OpenWrap/Configuration/Remotes/RemoteRepositories.cs
+++ b/src/OpenWrap/Configuration/Remotes/RemoteRepositories.cs
@@ -14,9 +14,9 @@ namespace OpenWrap.Configuration.Remotes
                     {
                         FetchRepository = new RemoteRepositoryEndpoint
                         {
-                            Token = "[indexed]http://wraps.openwrap.org"
+                            Token = "[indexed-http]http://wraps.openwrap.org"
                         },
-                        PublishRepositories = { new RemoteRepositoryEndpoint { Token = "[indexed]http://wraps.openwrap.org" } },
+                        PublishRepositories = { new RemoteRepositoryEndpoint { Token = "[indexed-http]http://wraps.openwrap.org" } },
                     }
                     }
             };

--- a/src/OpenWrap/Repositories/Http/HttpRepositoryNavigator.cs
+++ b/src/OpenWrap/Repositories/Http/HttpRepositoryNavigator.cs
@@ -31,6 +31,7 @@ namespace OpenWrap.Repositories.Http
         {
             get
             {
+                EnsureFileListLoaded();
                 return _fileList != null && _fileList.CanPublish;
             }
         }

--- a/src/OpenWrap/Repositories/Http/IndexedHttpRepository.cs
+++ b/src/OpenWrap/Repositories/Http/IndexedHttpRepository.cs
@@ -8,7 +8,7 @@ using OpenWrap.PackageModel;
 
 namespace OpenWrap.Repositories.Http
 {
-    public class IndexedHttpRepository : IPackageRepository, ISupportAuthentication
+    public class IndexedHttpRepository : IPackageRepository, ISupportPublishing, ISupportAuthentication
     {
         readonly IHttpRepositoryNavigator _navigator;
         readonly IEnumerable<HttpPackageInfo> _packagesQuery;


### PR DESCRIPTION
I think this very simple fix solves the issue with using -remote in list-wrap and also downloading packages with add-wrap from the OpenWrap repository.
