### PR TITLE
Fix initializing location of system repository. (see #328)

### DIFF
--- a/src/OpenWrap/Commands/Cli/ShellRunner.cs
+++ b/src/OpenWrap/Commands/Cli/ShellRunner.cs
@@ -39,7 +39,7 @@ namespace OpenWrap.Commands.Cli
                     }
                 };
                 if (env.SysPath() != null)
-                    cdenv.SystemRepositoryDirectory = LocalFileSystem.Instance.GetDirectory(new Path(env.SysPath()));
+                    cdenv.SystemRepositoryDirectory = LocalFileSystem.Instance.GetDirectory((new Path(env.SysPath())).Combine("wraps"));
 
                 return cdenv;
             });


### PR DESCRIPTION
I got really weird behavior every time I set out to test OpenWrap from master: o.exe always trying to re-download openwrap version 1. I think this is the culprit. Can you verify this?
