### PR TITLE
Fixing Target metadata on FilteredBuildOutput (see #335)

### DIFF
--- a/src/OpenWrap.Build.Tasks/OpenWrap.CSharp.targets
+++ b/src/OpenWrap.Build.Tasks/OpenWrap.CSharp.targets
@@ -112,8 +112,7 @@
   <Target Name="OpenWrap-AfterBuild"
           Condition="'$(OpenWrap-EmitOutputInstructions)' != 'false'">
 
-    <!-- Build results for the current project and associated project references-->
-
+    <!-- Build results for the current project and associated project references -->
 
     <!-- Binary result (.exe or .dll) -->
     <CreateItem Include="@(IntermediateAssembly)" AdditionalMetadata="TargetPath=.">
@@ -171,8 +170,7 @@
     
     <!-- All of those files that were not included by OpenWrap itself -->
     <CreateItem Include="@(_OpenWrap-CurrentBuildOutput)"
-                Condition="'%(_OpenWrap-CurrentBuildOutput.FromOpenWrap)' != 'True'"
-                    AdditionalMetadata="TargetPath=.">
+                Condition="'%(_OpenWrap-CurrentBuildOutput.FromOpenWrap)' != 'True'">
       <Output TaskParameter="Include" ItemName="_OpenWrap-FilteredBuildOutput"/>
     </CreateItem>
 


### PR DESCRIPTION
The main problem with the resource files not working, is that in the MSBuild code, the original Target metadata was overwritten in the last step "FilteredBuildOutput". This commit fixes this.
